### PR TITLE
Fix Nullpointer by avoiding that packet is send when manager variable is null.

### DIFF
--- a/src/main/java/socketio_client/Socket.java
+++ b/src/main/java/socketio_client/Socket.java
@@ -85,7 +85,6 @@ public class Socket extends Observable {
     }
 
     public void close() {
-        manager.sendPacket(new Packet(Type.DISCONNECT, namespace));
         disconnect();
     }
 
@@ -93,6 +92,7 @@ public class Socket extends Observable {
         if(state == State.CLOSED)
             return;
 
+        manager.sendPacket(new Packet(Type.DISCONNECT, namespace));
         manager.disconnectSocket(this);
         doCommonClosingCleanUp(DISCONNECT, args);
     }


### PR DESCRIPTION
The following patch should avoid an Nullpointer in case the close() method is called after the doCommonClosingCleanUp(...) has already reset the manager variable to null.